### PR TITLE
Add documentation for project map and style guide

### DIFF
--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -1,0 +1,62 @@
+# Project Map
+
+## Overview
+Physics Nook is a Create React App project that delivers interactive physics simulations and lesson content. The application bootstraps in `src/index.js`, wraps the UI in `BrowserRouter`, and renders routes defined in `src/App.js`, where the top navigation bar and page-level routing live.【F:src/index.js†L1-L16】【F:src/App.js†L1-L77】
+
+## Getting Started
+- `npm start` – launch the development server.
+- `npm test` – run the React Testing Library test suite.
+- `npm run build` – create a production build in `build/`.
+- `npm run generate-sitemap` – rebuild `public/sitemap.xml` using `generate-sitemap.js`.【F:package.json†L26-L37】【F:generate-sitemap.js†L1-L35】
+
+## Directory Overview
+| Path | Purpose | Highlights |
+| --- | --- | --- |
+| `src/` | React source for pages, simulations, styles, and entry points. | `index.js`, `App.js`, and root-level legacy simulations (e.g., `DoublePendulum.js`). |
+| `src/pages/` | Narrative lesson pages that compose simulations and explanatory text. | Topics include Kinematics, Electric Field, Chaos, Momentum, Sound, etc.; pages use `better-react-mathjax` where needed.【F:src/pages/Kinematics.js†L1-L112】 |
+| `src/components/` | Reusable and domain-specific simulation components grouped by subject. | Contains p5.js sketches, Plotly charts, audio synths, and shared UI like `HiddenExposition` accordions.【F:src/components/HiddenExposition.jsx†L1-L88】 |
+| `src/components/electricity/` | Electric field and potential visualizations. | Includes point charge field renderers and equipotential maps.【F:src/components/electricity/PotentialFieldSimulation.js†L1-L40】 |
+| `src/components/mechanics/` | Mechanics mini-simulations. | Currently contains `BeadOnRotatingRod.jsx` as an example of subject-specific grouping.【F:src/components/mechanics/BeadOnRotatingRod.jsx†L1-L40】 |
+| `src/components/shared/` | Cross-cutting UI helpers. | `HiddenExposition.jsx` and `HiddenQuestion.jsx` provide reusable interactive text reveals.【F:src/components/shared/HiddenExposition.jsx†L1-L88】 |
+| `src/assets/` | Bundled imagery referenced from React components. | Contains sprite sheets and illustrations such as `hawks.png` for the landing page animation.【F:src/LandingPage.js†L1-L76】 |
+| `src/styles/` | Global CSS organized by concern. | `main.css` imports topic-specific styles (`global.css`, `navbar.css`, `simulations.css`, etc.).【F:src/styles/main.css†L1-L8】 |
+| `public/` | Static assets served by CRA. | `index.html`, SEO files, and published sitemap. Contains `assets/` for images and `kinematics/index.html` for static hosting.【F:public/index.html†L1-L30】【F:public/sitemap.xml†L1-L5】 |
+| `build/` | Generated production bundle. | Populated by `npm run build` (kept in repo for deployment).【F:build/manifest.json†L1-L30】 |
+| `generate-sitemap.js` | Node script to regenerate the sitemap before builds. | Keep route list in sync with `App.js` navigation.【F:generate-sitemap.js†L1-L35】 |
+
+## Application Flow
+1. `index.js` bootstraps React and wraps the app in `BrowserRouter`.
+2. `App.js` renders the global navigation and declares route-to-page mappings with `<Routes>`.
+3. Each page in `src/pages/` composes textual content, MathJax blocks, and simulation components.
+4. Simulation components live in `src/components/` (often inside domain folders) and encapsulate canvas, Plotly, or audio logic using React hooks.
+5. Shared CSS from `src/styles/main.css` styles navigation, layouts, and responsive behavior while some simulations use inline styles for dynamic visuals.【F:src/App.js†L21-L77】【F:src/styles.css†L1-L72】
+
+## Pages and Featured Simulations
+- **LandingPage** – animates a starfield and sprite-based hawks on a `<canvas>`; links to featured simulations.【F:src/LandingPage.js†L1-L120】
+- **DoublePendulum**, **SpringMass**, **IdealGas** – legacy standalone simulations in the project root, each using hooks and, in some cases, `react-p5` for rendering.【F:src/DoublePendulum.js†L1-L82】
+- **Mechanics Pages** (`Kinematics`, `Kinematics2`, `Vectors`, `Momentum`, `Oscillations`) – blend MathJax exposition with components like `KinematicsSim`, `VelocityExplorer`, and question prompts.【F:src/pages/Kinematics.js†L1-L170】
+- **Electricity Pages** (`ElectricField`, `ElectricPotential`) – import simulations from `src/components/electricity` to visualize fields and equipotentials.
+- **Advanced Pages** (`Chaos`, `Sound`, `PolarKinematics`, etc.) – combine charts, canvas animations, and audio via domain components.
+
+## Styling
+- `src/styles/main.css` aggregates individual CSS files so pages can import one file for global styles.
+- `src/styles.css` contains additional layout rules and landing page styles; some simulations rely on inline styles or canvas drawing for dynamic visuals.【F:src/styles.css†L1-L94】
+- Responsive tweaks live in `src/styles/responsive.css`, primarily handling stacked layouts for canvases and control panels.【F:src/styles/responsive.css†L1-L21】
+
+## Assets
+- Place large static media (sprites, backgrounds) in `public/assets/` for direct URL access.
+- Keep React-bundled images in `src/assets/` and import them from components when needed.
+- Update any sprite-sheet dimensions or filenames referenced in code (e.g., LandingPage expects `/assets/hawks.png`).【F:src/LandingPage.js†L21-L59】
+
+## Testing and QA
+- `src/App.test.js` contains the default React Testing Library scaffold—extend this or add new test files alongside components when adding features.【F:src/App.test.js†L1-L9】
+- Jest-DOM matchers are configured in `src/setupTests.js`.【F:src/setupTests.js†L1-L5】
+
+## Adding New Content Checklist
+1. Create the new page component under `src/pages/` (PascalCase file name).
+2. Build or import supporting simulations under `src/components/` (create a subfolder if a new subject area emerges).
+3. Register the route and navigation link in `src/App.js` and ensure `generate-sitemap.js` includes the new route for SEO.
+4. Add or update CSS in `src/styles/` (and import it from `main.css` if globally required).
+5. Update any relevant assets under `src/assets/` or `public/assets/`.
+6. Write or update tests with React Testing Library when functionality changes.
+7. Run `npm run generate-sitemap`, `npm test`, and `npm run build` before deployment.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,45 @@
+# Style Guide
+
+## Core Principles
+- **Teach through interaction.** Prioritize simulations that reinforce the written exposition on each page. Keep text concise and let controls encourage exploration, mirroring the existing lesson pages in `src/pages/`.【F:src/pages/Kinematics.js†L1-L112】
+- **Use idiomatic React.** All UI is built with function components and React hooks (`useState`, `useRef`, `useEffect`, etc.). Follow the patterns used in `App.js`, `LandingPage.js`, and the simulation components.【F:src/App.js†L1-L77】【F:src/LandingPage.js†L1-L76】
+- **Keep routing and SEO in sync.** Every new page must be registered in `App.js` and added to `generate-sitemap.js` so deployment builds publish correct navigation and sitemap metadata.【F:src/App.js†L21-L77】【F:generate-sitemap.js†L1-L35】
+
+## JavaScript & React Conventions
+- **Functional components only.** Do not introduce class components; stateful logic should use hooks as demonstrated in simulations like `DoublePendulum.js` and `BeadOnRotatingRod.jsx`.【F:src/DoublePendulum.js†L1-L82】【F:src/components/mechanics/BeadOnRotatingRod.jsx†L1-L36】
+- **Localize state.** Keep simulation state (`useState`, `useRef`) inside the component that owns the animation or visualization. Expose props only when parent pages need to control a child simulation.
+- **Side effects in `useEffect`.** Handle canvas resizing, animation loops, and data fetching inside `useEffect` blocks with appropriate cleanup to avoid memory leaks.【F:src/LandingPage.js†L29-L73】
+- **Prefer descriptive comments.** Complex physics logic should include top-of-file docblocks and inline explanations as seen across the mechanics and electricity simulations.【F:src/components/mechanics/BeadOnRotatingRod.jsx†L1-L22】【F:src/components/electricity/PotentialFieldSimulation.js†L1-L26】
+
+## File Organization & Naming
+- **Pages vs. components.** Place lesson pages in `src/pages/` and reusable simulations in `src/components/`, creating subfolders (`electricity`, `mechanics`, `shared`, etc.) to group related logic.【F:src/components/electricity/PotentialFieldSimulation.js†L1-L8】
+- **PascalCase files.** Name React component files using PascalCase (`Kinematics.js`, `HiddenExposition.jsx`). Export a component with the same name as the file.
+- **Assets.** Store images that need bundling in `src/assets/` and reference them via imports. Put large or static files in `public/assets/` and reference them with absolute URLs (as done by `LandingPage` for the hawk sprites).【F:src/LandingPage.js†L33-L59】
+
+## Styling Guidelines
+- **Centralized imports.** Add new global styles inside `src/styles/` and import them through `src/styles/main.css` so that `App.js` pulls in a single stylesheet.【F:src/styles/main.css†L1-L8】
+- **Use classes for layout.** Leverage existing class names (`container`, `simulation-grid`, etc.) from `src/styles.css` for consistent layout. Add new classes there or in a domain-specific stylesheet instead of inline styles when the styling is static.【F:src/styles.css†L1-L94】
+- **Responsive design.** Mirror the responsive breakpoints defined in `src/styles/responsive.css` when adding new flex/grid layouts, ensuring controls stack cleanly on tablets and phones.【F:src/styles/responsive.css†L1-L21】
+- **Inline styles for dynamic visuals.** Inline styles are acceptable when driven by component state (e.g., simulation canvases, toggled cards). Keep them focused and memoized if they become complex.【F:src/components/HiddenExposition.jsx†L1-L40】
+
+## Math, Text, and Accessibility
+- **MathJax for formulas.** Use `better-react-mathjax` with `MathJaxContext` to render equations; wrap inline expressions with `MathJax inline` and block expressions in standalone `MathJax` components as shown in `Kinematics.js`.【F:src/pages/Kinematics.js†L1-L112】
+- **Semantic structure.** Follow the heading hierarchy used on existing pages (`<h1>` title, `<h2>` sections) and keep explanatory text left-aligned using the `.left-aligned-container` styles.【F:src/pages/Kinematics.js†L19-L105】【F:src/styles.css†L21-L40】
+- **Accessible controls.** Provide keyboard instructions and labelled controls for simulations; ensure interactive components expose ARIA attributes when content is toggled (see `HiddenExposition.jsx`).【F:src/components/HiddenExposition.jsx†L21-L55】
+
+## Simulation Patterns
+- **Canvas & animation.** Use `useRef` to hold animation state and requestAnimationFrame IDs, resizing canvases responsively as shown in `LandingPage.js`. Clean up observers or RAF handles on unmount.【F:src/LandingPage.js†L29-L109】
+- **p5.js sketches.** For `react-p5` components, define `setup` and `draw` functions inside the component and rely on refs to store simulation state, following `DoublePendulum.js` as a template.【F:src/DoublePendulum.js†L23-L82】
+- **Physics parameters.** Expose user-facing controls for key parameters using controlled inputs. Keep parameter defaults near the top of the component for quick scanning, as demonstrated in multiple simulations.【F:src/DoublePendulum.js†L5-L21】【F:src/components/mechanics/BeadOnRotatingRod.jsx†L19-L33】
+
+## Testing & Quality Assurance
+- **React Testing Library.** Add or extend tests in `src/App.test.js` or create new `*.test.js(x)` files alongside features. Keep assertions focused on user-facing behavior; Jest DOM is preconfigured in `src/setupTests.js`.【F:src/App.test.js†L1-L9】【F:src/setupTests.js†L1-L5】
+- **Manual verification.** For simulations, verify performance at 60fps on desktop and acceptable responsiveness on mobile breakpoints defined in the CSS.
+- **Pre-deploy checks.** Before releasing, run `npm run generate-sitemap`, `npm test`, and `npm run build` to confirm the sitemap, tests, and production bundle succeed.【F:package.json†L26-L37】【F:generate-sitemap.js†L1-L35】
+
+## Content & Deployment Workflow
+1. Draft or update the lesson page in `src/pages/` with supporting simulations.
+2. Import simulations from `src/components/` and add links to the navigation in `App.js`.
+3. Update copy to include control instructions and inline explanations similar to existing sections.
+4. Update assets and styles as needed, keeping layout responsive.
+5. Regenerate the sitemap and run the test/build commands prior to pushing to production.


### PR DESCRIPTION
## Summary
- add PROJECT_MAP.md to document the application structure, major directories, and key workflows
- add STYLE_GUIDE.md that captures React, styling, and content conventions for future contributors

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68d02d4f3fc48326bfc08e3d228e327a